### PR TITLE
Fix the composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,13 @@
     ],
     "require": {
         "php" : ">=5.4",
-        "behat/behat" : "^3.0.0",
+        "bex/behat-screenshot": "^1.0",
+        "bex/behat-extension-driver-locator": "^1.0",
         "kriswallsmith/buzz": "^0.15.0"
     },
     "require-dev": {
         "phpspec/phpspec" : "2.4.0-alpha2",
-        "bex/behat-extension-driver-locator": "*",
-        "bex/behat-screenshot": "*",
-        "bex/behat-test-runner": "*",
+        "bex/behat-test-runner": "^1.1",
         "jakoch/phantomjs-installer": "^1.9.8",
         "behat/mink-selenium2-driver": "^1.3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "require": {
         "php" : ">=5.4",
         "bex/behat-screenshot": "^1.0",
-        "bex/behat-extension-driver-locator": "^1.0",
         "kriswallsmith/buzz": "^0.15.0"
     },
     "require-dev": {


### PR DESCRIPTION
- `bex/behat-screenshot` and `bex/behat-extension-driver-locator` are mandatory dependencies of the package because of the interface implemented by the driver, not dev dependencies
- `behat/behat` is not actually used in this package, so there is no reason to require it
